### PR TITLE
Includes timezone when quering server

### DIFF
--- a/src/main/resources/dist/js/org.wattdepot.client.js
+++ b/src/main/resources/dist/js/org.wattdepot.client.js
@@ -78,20 +78,7 @@ org.WattDepot.Client = function(url) {
    * string.
    */
   function getTimestampFromDate(date) {
-    function padZero(number, length) {
-      var str = '' + number;
-      while (str.length < length) {
-        str = '0' + str;
-      }
-      return str;
-    }
-
-    var timestamp = date.getFullYear() + '-' + padZero(date.getMonth() + 1, 2)
-        + '-' + padZero(date.getDate(), 2);
-    timestamp = timestamp + 'T' + padZero(date.getHours(), 2) + ':'
-        + padZero(date.getMinutes(), 2) + ':' + padZero(date.getSeconds(), 2);
-    timestamp = timestamp + '.' + padZero(date.getMilliseconds(), 3);
-    return timestamp;
+    return date.toISOString();
   }
 
   /*


### PR DESCRIPTION
This fixes Issue #81 
toISOString will convert the date to UTC timezone and correctly format it according to ISO 8601. It is supported in all major browsers: 
http://www.w3schools.com/Jsref/jsref_toisostring.asp
Only downside of this approach is that the server won't know which timezone the request was made in.